### PR TITLE
docs: fixes for wrong version range in package-lock

### DIFF
--- a/src/documentation/0020-package-lock-json/index.md
+++ b/src/documentation/0020-package-lock-json/index.md
@@ -15,7 +15,7 @@ The goal of `package-lock.json` file is to keep track of the exact version of ev
 This solves a very specific problem that `package.json` left unsolved. In package.json you can set which versions you want to upgrade to (patch or minor), using the **semver** notation, for example:
 
 * if you write `~0.13.0`, you want to only update patch releases: `0.13.1` is ok, but `0.14.0` is not.
-* if you write `^0.13.0`, you want to get updates that do not change the leftmost non-zero number: `0.13.1`, `0.13.2` and so on. If you write `^1.13.0`, you will get patch and minor releases: `1.13.1`, `1.14.0` and so on up to `2.0.0`.
+* if you write `^0.13.0`, you want to get updates that do not change the leftmost non-zero number: `0.13.1`, `0.13.2` and so on. If you write `^1.13.0`, you will get patch and minor releases: `1.13.1`, `1.14.0` and so on up to `2.0.0` but not `2.0.0`.
 * if you write `0.13.0`, that is the exact version that will be used, always
 
 You don't commit to Git your node_modules folder, which is generally huge, and when you try to replicate the project on another machine by using the `npm install` command, if you specified the `~` syntax and a patch release of a package has been released, that one is going to be installed. Same for `^` and minor releases.


### PR DESCRIPTION
## Description
Adding 'but not `2.0.0`' to the version range to further clarify the significance of using `^` in versions

## Related Issues
Addresses #1832

